### PR TITLE
Merge bz17645

### DIFF
--- a/BZ-17645.md
+++ b/BZ-17645.md
@@ -1,0 +1,17 @@
+# BZ-17645 Patch
+## Summary
+This patch provide a new sorting algorithm for shared objects in the dynamic loader, which solves the slow behavior that the current (pre glibc 2.35) "old" algorithm falls into when the DSO set contains circular dependencies.
+
+## Bug Description 
+This performance issue was first reported in November 2014 [RFE: Improve performance of dynamic loader for deeply nested DSO dependencies](https://sourceware.org/bugzilla/show_bug.cgi?id=17645) by Paulo Andrade. Recently MathWorks discovered that this  issue is affecting the shutdown performance of MATLAB and Simulink. The shutdown performance is degenerated release by release and even getting worse with recent versions of glibc prior to 2.35. From a most recent (2022) benchmark, the shutdown time of MATLAB and Simulink in a Debian 11 environment (glibc-2.31) is about 300 seconds with modern hardwares. This significantly affect user experience and CI workflows. We tested in house with this patch applied and enabled, and the shutdown time was reduced to less than 3 seconds with same hardwares that did the previous benchmark. 
+
+
+## Patch sources
+This patch contains a new implementation of _dl_sort_maps first introduced here [RFE: Improve performance of dynamic loader for deeply nested DSO dependencies](https://sourceware.org/bugzilla/show_bug.cgi?id=17645) by Paulo Andrade in 2014 and later incorporated into the master branch of glibc 2.35 by Chung-Lin Tang <cltang@codesourcery.com> and Adhemerval Zanella <azanella@sourceware.org> in the following commit:
+
+* https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=15a0c5730d1d5aeb95f50c9ec7470640084feae8. 
+
+Mathworks modify the patch to remove the tunnable and set the new DFS sorting algorithm to the default behavior.
+
+## Acknowledgement and thanks
+Many thanks to the broader glibc team and particularly Paulo Andrade for reporting the issue and providing the original implemetation, Chung-Lin Tang and Adhemerval Zanella for incorporate the new sorting algorithm in glibc v2.35 and providing the original patch.

--- a/BZ-17645.md
+++ b/BZ-17645.md
@@ -1,17 +1,14 @@
 # BZ-17645 Patch
 ## Summary
-This patch provide a new sorting algorithm for shared objects in the dynamic loader, which solves the slow behavior that the current (pre glibc 2.35) "old" algorithm falls into when the DSO set contains circular dependencies.
+This patch resolves a performance issue that affects MATLAB and Simulink shutdown performance. The patch provides a new sorting algorithm for shared objects in the dynamic loader. The original algorithm in glibc versions prior to glibc 2.35 is slow when the DSO set contains circular dependencies.
 
 ## Bug Description 
-This performance issue was first reported in November 2014 [RFE: Improve performance of dynamic loader for deeply nested DSO dependencies](https://sourceware.org/bugzilla/show_bug.cgi?id=17645) by Paulo Andrade. Recently MathWorks discovered that this  issue is affecting the shutdown performance of MATLAB and Simulink. The shutdown performance is degenerated release by release and even getting worse with recent versions of glibc prior to 2.35. From a most recent (2022) benchmark, the shutdown time of MATLAB and Simulink in a Debian 11 environment (glibc-2.31) is about 300 seconds with modern hardwares. This significantly affect user experience and CI workflows. We tested in house with this patch applied and enabled, and the shutdown time was reduced to less than 3 seconds with same hardwares that did the previous benchmark. 
+The performance issue impacts the MATLAB and Simulink shutdown time. In a Debian 11 environment using glibc 2.31, the MATLAB and Simulink shutdown time is about 300 seconds with modern hardware. With the same setup and the patch enabled, the shutdown time is less than 3 seconds. The performance issue was first reported in November of 2014 by Paulo Andrade. For more information, see [RFE: Improve performance of dynamic loader for deeply nested DSO dependencies](https://sourceware.org/bugzilla/show_bug.cgi?id=17645). 
 
+## Patch Sources
+This patch contains a new implementation of _dl_sort_maps, which Paulo Andrade introduced in [RFE: Improve performance of dynamic loader for deeply nested DSO dependencies](https://sourceware.org/bugzilla/show_bug.cgi?id=17645). Chung-Lin Tang <cltang@codesourcery.com> and Adhemerval Zanella <azanella@sourceware.org> later incorporated the new implementation into the master branch of glibc 2.35 in the commit [elf: Fix slow DSO sorting behavior in dynamic loader (BZ #17645)](https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=15a0c5730d1d5aeb95f50c9ec7470640084feae8).
 
-## Patch sources
-This patch contains a new implementation of _dl_sort_maps first introduced here [RFE: Improve performance of dynamic loader for deeply nested DSO dependencies](https://sourceware.org/bugzilla/show_bug.cgi?id=17645) by Paulo Andrade in 2014 and later incorporated into the master branch of glibc 2.35 by Chung-Lin Tang <cltang@codesourcery.com> and Adhemerval Zanella <azanella@sourceware.org> in the following commit:
+The MathWorks BZ-17645 patch sets the new DFS sorting algorithm as the default behavior.
 
-* https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=15a0c5730d1d5aeb95f50c9ec7470640084feae8. 
-
-Mathworks modify the patch to remove the tunnable and set the new DFS sorting algorithm to the default behavior.
-
-## Acknowledgement and thanks
-Many thanks to the broader glibc team and particularly Paulo Andrade for reporting the issue and providing the original implemetation, Chung-Lin Tang and Adhemerval Zanella for incorporate the new sorting algorithm in glibc v2.35 and providing the original patch.
+## Acknowledgements and Thanks
+Many thanks to the glibc team and, particularly, Paulo Andrade for reporting the issue and providing the original implementation and Chung-Lin Tang and Adhemerval Zanella for incorporating the new sorting algorithm into glibc 2.35 and providing the original patch.

--- a/patches/rhel/2.28/unsubmitted-mathworks-0-bz17645.v2.28-rhel.patch
+++ b/patches/rhel/2.28/unsubmitted-mathworks-0-bz17645.v2.28-rhel.patch
@@ -1,0 +1,561 @@
+**************************ORIGINAL HEADER*****************************
+From patchwork Thu Oct 21 13:41:22 2021
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: Chung-Lin Tang <cltang@codesourcery.com>
+X-Patchwork-Id: 46497
+Return-Path: <libc-alpha-bounces+patchwork=sourceware.org@sourceware.org>
+X-Original-To: patchwork@sourceware.org
+Delivered-To: patchwork@sourceware.org
+Received: from server2.sourceware.org (localhost [IPv6:::1])
+	by sourceware.org (Postfix) with ESMTP id B66BB3857801
+	for <patchwork@sourceware.org>; Thu, 21 Oct 2021 13:41:58 +0000 (GMT)
+X-Original-To: libc-alpha@sourceware.org
+Delivered-To: libc-alpha@sourceware.org
+Received: from seed.net.tw (sn15.seed.net.tw [139.175.54.15])
+ by sourceware.org (Postfix) with ESMTP id 3B6AC3858405
+ for <libc-alpha@sourceware.org>; Thu, 21 Oct 2021 13:41:41 +0000 (GMT)
+DMARC-Filter: OpenDMARC Filter v1.4.1 sourceware.org 3B6AC3858405
+Authentication-Results: sourceware.org; dmarc=none (p=none dis=none)
+ header.from=codesourcery.com
+Authentication-Results: sourceware.org;
+ spf=none smtp.mailfrom=codesourcery.com
+Received: from [112.104.15.59] (port=35230 helo=localhost.localdomain)
+ by seed.net.tw with esmtp (Seednet 4.69:2)
+ id 1mdYK9-000NfF-1W; Thu, 21 Oct 2021 21:41:37 +0800
+From: Chung-Lin Tang <cltang@codesourcery.com>
+To: libc-alpha@sourceware.org,
+ Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Subject: [PATCH v8 2/2] elf: Fix slow DSO sorting behavior in dynamic loader
+ (BZ #17645)
+Date: Thu, 21 Oct 2021 21:41:22 +0800
+Message-Id: <20211021134122.3141-2-cltang@codesourcery.com>
+X-Mailer: git-send-email 2.17.1
+In-Reply-To: <20211021134122.3141-1-cltang@codesourcery.com>
+References: <20211021134122.3141-1-cltang@codesourcery.com>
+X-Spam-Status: No, score=-19.6 required=5.0 tests=BAYES_00, FORGED_SPF_HELO,
+ GIT_PATCH_0, KAM_DMARC_STATUS, KAM_LAZY_DOMAIN_SECURITY, KAM_SHORT,
+ RCVD_IN_DNSWL_LOW, SPF_HELO_PASS, SPF_NONE,
+ TXREP autolearn=ham autolearn_force=no version=3.4.4
+X-Spam-Checker-Version: SpamAssassin 3.4.4 (2020-01-24) on
+ server2.sourceware.org
+X-BeenThere: libc-alpha@sourceware.org
+X-Mailman-Version: 2.1.29
+Precedence: list
+List-Id: Libc-alpha mailing list <libc-alpha.sourceware.org>
+List-Unsubscribe: <https://sourceware.org/mailman/options/libc-alpha>,
+ <mailto:libc-alpha-request@sourceware.org?subject=unsubscribe>
+List-Archive: <https://sourceware.org/pipermail/libc-alpha/>
+List-Post: <mailto:libc-alpha@sourceware.org>
+List-Help: <mailto:libc-alpha-request@sourceware.org?subject=help>
+List-Subscribe: <https://sourceware.org/mailman/listinfo/libc-alpha>,
+ <mailto:libc-alpha-request@sourceware.org?subject=subscribe>
+Errors-To: libc-alpha-bounces+patchwork=sourceware.org@sourceware.org
+Sender: "Libc-alpha"
+ <libc-alpha-bounces+patchwork=sourceware.org@sourceware.org>
+
+This second patch contains the actual implementation of a new sorting algorithm
+for shared objects in the dynamic loader, which solves the slow behavior that
+the current "old" algorithm falls into when the DSO set contains circular
+dependencies.
+
+The new algorithm implemented here is simply depth-first search (DFS) to obtain
+the Reverse-Post Order (RPO) sequence, a topological sort. A new l_visited:1
+bitfield is added to struct link_map to more elegantly facilitate such a search.
+
+The DFS algorithm is applied to the input maps[nmap-1] backwards towards
+maps[0]. This has the effect of a more "shallow" recursion depth in general
+since the input is in BFS. Also, when combined with the natural order of
+processing l_initfini[] at each node, this creates a resulting output sorting
+closer to the intuitive "left-to-right" order in most cases.
+
+Another notable implementation adjustment related to this _dl_sort_maps change
+is the removing of two char arrays 'used' and 'done' in _dl_close_worker to
+represent two per-map attributes. This has been changed to simply use two new
+bit-fields l_map_used:1, l_map_done:1 added to struct link_map. This also allows
+discarding the clunky 'used' array sorting that _dl_sort_maps had to sometimes
+do along the way.
+
+Tunable support for switching between different sorting algorithms at runtime is
+also added. A new tunable 'glibc.rtld.dynamic_sort' with current valid values 1
+(old algorithm) and 2 (new DFS algorithm) has been added. At time of commit
+of this patch, the default setting is 1 (old algorithm).
+
+Signed-off-by: Chung-Lin Tang  <cltang@codesourcery.com>
+Reviewed-by: Adhemerval Zanella  <adhemerval.zanella@linaro.org>
+**********************************************************************************
+
+Mathworks
+Backport to glibc 2.28 for RHEL, remove tunable support and set default to the DFS sort map behavior
+
+Coded-by: Alan Li <alanli@mathworks.com>
+
+
+diff --git a/elf/dl-close.c b/elf/dl-close.c
+index 73b2817..cfad816 100644
+--- a/elf/dl-close.c
++++ b/elf/dl-close.c
+@@ -164,8 +164,6 @@ _dl_close_worker (struct link_map *map, bool force)
+ 
+   bool any_tls = false;
+   const unsigned int nloaded = ns->_ns_nloaded;
+-  char used[nloaded];
+-  char done[nloaded];
+   struct link_map *maps[nloaded];
+ 
+   /* Run over the list and assign indexes to the link maps and enter
+@@ -173,24 +171,21 @@ _dl_close_worker (struct link_map *map, bool force)
+   int idx = 0;
+   for (struct link_map *l = ns->_ns_loaded; l != NULL; l = l->l_next)
+     {
+-      l->l_idx = idx;
++      l->l_map_used = 0;
++      l->l_map_done = 0;
++	  l->l_idx = idx;
+       maps[idx] = l;
+       ++idx;
+-
+     }
+   assert (idx == nloaded);
+ 
+-  /* Prepare the bitmaps.  */
+-  memset (used, '\0', sizeof (used));
+-  memset (done, '\0', sizeof (done));
+-
+   /* Keep track of the lowest index link map we have covered already.  */
+   int done_index = -1;
+   while (++done_index < nloaded)
+     {
+       struct link_map *l = maps[done_index];
+ 
+-      if (done[done_index])
++      if (l->l_map_done)
+ 	/* Already handled.  */
+ 	continue;
+ 
+@@ -201,12 +196,12 @@ _dl_close_worker (struct link_map *map, bool force)
+ 	  /* See CONCURRENCY NOTES in cxa_thread_atexit_impl.c to know why
+ 	     acquire is sufficient and correct.  */
+ 	  && atomic_load_acquire (&l->l_tls_dtor_count) == 0
+-	  && !used[done_index])
++	  && !l->l_map_used)
+ 	continue;
+ 
+       /* We need this object and we handle it now.  */
+-      done[done_index] = 1;
+-      used[done_index] = 1;
++      l->l_map_used = 1;
++      l->l_map_done = 1;
+       /* Signal the object is still needed.  */
+       l->l_idx = IDX_STILL_USED;
+ 
+@@ -222,9 +217,9 @@ _dl_close_worker (struct link_map *map, bool force)
+ 		{
+ 		  assert ((*lp)->l_idx >= 0 && (*lp)->l_idx < nloaded);
+ 
+-		  if (!used[(*lp)->l_idx])
++		  if (!(*lp)->l_map_used)
+ 		    {
+-		      used[(*lp)->l_idx] = 1;
++		      (*lp)->l_map_used = 1;
+ 		      /* If we marked a new object as used, and we've
+ 			 already processed it, then we need to go back
+ 			 and process again from that point forward to
+@@ -247,9 +242,9 @@ _dl_close_worker (struct link_map *map, bool force)
+ 	      {
+ 		assert (jmap->l_idx >= 0 && jmap->l_idx < nloaded);
+ 
+-		if (!used[jmap->l_idx])
++		if (!jmap->l_map_used)
+ 		  {
+-		    used[jmap->l_idx] = 1;
++		    jmap->l_map_used = 1;
+ 		    if (jmap->l_idx - 1 < done_index)
+ 		      done_index = jmap->l_idx - 1;
+ 		  }
+@@ -259,8 +254,7 @@ _dl_close_worker (struct link_map *map, bool force)
+ 
+   /* Sort the entries.  We can skip looking for the binary itself which is
+      at the front of the search list for the main namespace.  */
+-  _dl_sort_maps (maps + (nsid == LM_ID_BASE), nloaded - (nsid == LM_ID_BASE),
+-		 used + (nsid == LM_ID_BASE), true);
++  _dl_sort_maps (maps, nloaded, (nsid == LM_ID_BASE), true);
+ 
+   /* Call all termination functions at once.  */
+ #ifdef SHARED
+@@ -277,7 +271,7 @@ _dl_close_worker (struct link_map *map, bool force)
+       /* All elements must be in the same namespace.  */
+       assert (imap->l_ns == nsid);
+ 
+-      if (!used[i])
++      if (!imap->l_map_used)
+ 	{
+ 	  assert (imap->l_type == lt_loaded && !imap->l_nodelete_active);
+ 
+@@ -330,7 +324,7 @@ _dl_close_worker (struct link_map *map, bool force)
+ 	  if (i < first_loaded)
+ 	    first_loaded = i;
+ 	}
+-      /* Else used[i].  */
++      /* Else imap->l_map_used.  */
+       else if (imap->l_type == lt_loaded)
+ 	{
+ 	  struct r_scope_elem *new_list = NULL;
+@@ -554,7 +548,7 @@ _dl_close_worker (struct link_map *map, bool force)
+   for (unsigned int i = first_loaded; i < nloaded; ++i)
+     {
+       struct link_map *imap = maps[i];
+-      if (!used[i])
++      if (!imap->l_map_used)
+ 	{
+ 	  assert (imap->l_type == lt_loaded);
+ 
+diff --git a/elf/dl-deps.c b/elf/dl-deps.c
+index 087a49b212..237d9636c5 100644
+--- a/elf/dl-deps.c
++++ b/elf/dl-deps.c
+@@ -613,10 +613,9 @@ Filters not supported with LD_TRACE_PRELINKING"));
+ 
+   /* If libc.so.6 is the main map, it participates in the sort, so
+      that the relocation order is correct regarding libc.so.6.  */
+-  if (l_initfini[0] == GL (dl_ns)[l_initfini[0]->l_ns].libc_map)
+-    _dl_sort_maps (l_initfini, nlist, NULL, false);
+-  else
+-    _dl_sort_maps (&l_initfini[1], nlist - 1, NULL, false);
++  _dl_sort_maps (l_initfini, nlist,
++		 (l_initfini[0] != GL (dl_ns)[l_initfini[0]->l_ns].libc_map),
++		 false);
+ 
+   /* Terminate the list of dependencies.  */
+   l_initfini[nlist] = NULL;
+diff --git a/elf/dl-fini.c b/elf/dl-fini.c
+index 226a6f0..afecbd1 100644
+--- a/elf/dl-fini.c
++++ b/elf/dl-fini.c
+@@ -91,8 +91,7 @@ _dl_fini (void)
+ 	  /* Now we have to do the sorting.  We can skip looking for the
+ 	     binary itself which is at the front of the search list for
+ 	     the main namespace.  */
+-	  _dl_sort_maps (maps + (ns == LM_ID_BASE), nmaps - (ns == LM_ID_BASE),
+-			 NULL, true);
++	  _dl_sort_maps (maps, nmaps, (ns == LM_ID_BASE), true);
+ 
+ 	  /* We do not rely on the linked list of loaded object anymore
+ 	     from this point on.  We have our own list here (maps).  The
+diff --git a/elf/dl-sort-maps.c b/elf/dl-sort-maps.c
+index b2a01ed..78d8693 100644
+--- a/elf/dl-sort-maps.c
++++ b/elf/dl-sort-maps.c
+@@ -1,5 +1,5 @@
+ /* Sort array of link maps according to dependencies.
+-   Copyright (C) 2017-2018 Free Software Foundation, Inc.
++   Copyright (C) 2017-2022 Free Software Foundation, Inc.
+    This file is part of the GNU C Library.
+ 
+    The GNU C Library is free software; you can redistribute it and/or
+@@ -14,109 +14,172 @@
+ 
+    You should have received a copy of the GNU Lesser General Public
+    License along with the GNU C Library; if not, see
+-   <http://www.gnu.org/licenses/>.  */
++   <https://www.gnu.org/licenses/>.  */
+ 
++#include <assert.h>
+ #include <ldsodefs.h>
+ 
+ 
+-/* Sort array MAPS according to dependencies of the contained objects.
+-   Array USED, if non-NULL, is permutated along MAPS.  If FOR_FINI this is
+-   called for finishing an object.  */
+-void
+-_dl_sort_maps (struct link_map **maps, unsigned int nmaps, char *used,
+-	       bool for_fini)
++/* We use a recursive function due to its better clarity and ease of
++   implementation, as well as faster execution speed. We already use
++   alloca() for list allocation during the breadth-first search of
++   dependencies in _dl_map_object_deps(), and this should be on the
++   same order of worst-case stack usage.
++
++   Note: the '*rpo' parameter is supposed to point to one past the
++   last element of the array where we save the sort results, and is
++   decremented before storing the current map at each level.  */
++
++static void
++dfs_traversal (struct link_map ***rpo, struct link_map *map,
++	       bool *do_reldeps)
+ {
+-  /* A list of one element need not be sorted.  */
+-  if (nmaps <= 1)
++  /* _dl_map_object_deps ignores l_faked objects when calculating the
++     number of maps before calling _dl_sort_maps, ignore them as well.  */
++  if (map->l_visited || map->l_faked)
+     return;
+ 
+-  unsigned int i = 0;
+-  uint16_t seen[nmaps];
+-  memset (seen, 0, nmaps * sizeof (seen[0]));
+-  while (1)
+-    {
+-      /* Keep track of which object we looked at this round.  */
+-      ++seen[i];
+-      struct link_map *thisp = maps[i];
++  map->l_visited = 1;
+ 
+-      if (__glibc_unlikely (for_fini))
++  if (map->l_initfini)
++    {
++      for (int i = 0; map->l_initfini[i] != NULL; i++)
+ 	{
+-	  /* Do not handle ld.so in secondary namespaces and objects which
+-	     are not removed.  */
+-	  if (thisp != thisp->l_real || thisp->l_idx == -1)
+-	    goto skip;
++	  struct link_map *dep = map->l_initfini[i];
++	  if (dep->l_visited == 0
++	      && dep->l_main_map == 0)
++	    dfs_traversal (rpo, dep, do_reldeps);
+ 	}
++    }
+ 
+-      /* Find the last object in the list for which the current one is
+-	 a dependency and move the current object behind the object
+-	 with the dependency.  */
+-      unsigned int k = nmaps - 1;
+-      while (k > i)
++  if (__glibc_unlikely (do_reldeps != NULL && map->l_reldeps != NULL))
++    {
++      /* Indicate that we encountered relocation dependencies during
++	 traversal.  */
++      *do_reldeps = true;
++
++      for (int m = map->l_reldeps->act - 1; m >= 0; m--)
+ 	{
+-	  struct link_map **runp = maps[k]->l_initfini;
+-	  if (runp != NULL)
+-	    /* Look through the dependencies of the object.  */
+-	    while (*runp != NULL)
+-	      if (__glibc_unlikely (*runp++ == thisp))
+-		{
+-		move:
+-		  /* Move the current object to the back past the last
+-		     object with it as the dependency.  */
+-		  memmove (&maps[i], &maps[i + 1],
+-			   (k - i) * sizeof (maps[0]));
+-		  maps[k] = thisp;
+-
+-		  if (used != NULL)
+-		    {
+-		      char here_used = used[i];
+-		      memmove (&used[i], &used[i + 1],
+-			       (k - i) * sizeof (used[0]));
+-		      used[k] = here_used;
+-		    }
+-
+-		  if (seen[i + 1] > nmaps - i)
+-		    {
+-		      ++i;
+-		      goto next_clear;
+-		    }
+-
+-		  uint16_t this_seen = seen[i];
+-		  memmove (&seen[i], &seen[i + 1], (k - i) * sizeof (seen[0]));
+-		  seen[k] = this_seen;
+-
+-		  goto next;
+-		}
+-
+-	  if (__glibc_unlikely (for_fini && maps[k]->l_reldeps != NULL))
+-	    {
+-	      unsigned int m = maps[k]->l_reldeps->act;
+-	      struct link_map **relmaps = &maps[k]->l_reldeps->list[0];
+-
+-	      /* Look through the relocation dependencies of the object.  */
+-	      while (m-- > 0)
+-		if (__glibc_unlikely (relmaps[m] == thisp))
+-		  {
+-		    /* If a cycle exists with a link time dependency,
+-		       preserve the latter.  */
+-		    struct link_map **runp = thisp->l_initfini;
+-		    if (runp != NULL)
+-		      while (*runp != NULL)
+-			if (__glibc_unlikely (*runp++ == maps[k]))
+-			  goto ignore;
+-		    goto move;
+-		  }
+-	    ignore:;
+-	    }
+-
+-	  --k;
++	  struct link_map *dep = map->l_reldeps->list[m];
++	  if (dep->l_visited == 0
++	      && dep->l_main_map == 0)
++	    dfs_traversal (rpo, dep, do_reldeps);
+ 	}
++    }
++
++  *rpo -= 1;
++  **rpo = map;
++}
+ 
+-    skip:
+-      if (++i == nmaps)
+-	break;
+-    next_clear:
+-      memset (&seen[i], 0, (nmaps - i) * sizeof (seen[0]));
++/* Topologically sort array MAPS according to dependencies of the contained
++   objects.  */
+ 
+-    next:;
++static void
++_dl_sort_maps_dfs (struct link_map **maps, unsigned int nmaps,
++		   unsigned int skip __attribute__ ((unused)), bool for_fini)
++{
++  for (int i = nmaps - 1; i >= 0; i--)
++    maps[i]->l_visited = 0;
++
++  /* We apply DFS traversal for each of maps[i] until the whole total order
++     is found and we're at the start of the Reverse-Postorder (RPO) sequence,
++     which is a topological sort.
++
++     We go from maps[nmaps - 1] backwards towards maps[0] at this level.
++     Due to the breadth-first search (BFS) ordering we receive, going
++     backwards usually gives a more shallow depth-first recursion depth,
++     adding more stack usage safety. Also, combined with the natural
++     processing order of l_initfini[] at each node during DFS, this maintains
++     an ordering closer to the original link ordering in the sorting results
++     under most simpler cases.
++
++     Another reason we order the top level backwards, it that maps[0] is
++     usually exactly the main object of which we're in the midst of
++     _dl_map_object_deps() processing, and maps[0]->l_initfini[] is still
++     blank. If we start the traversal from maps[0], since having no
++     dependencies yet filled in, maps[0] will always be immediately
++     incorrectly placed at the last place in the order (first in reverse).
++     Adjusting the order so that maps[0] is last traversed naturally avoids
++     this problem.
++
++     Further, the old "optimization" of skipping the main object at maps[0]
++     from the call-site (i.e. _dl_sort_maps(maps+1,nmaps-1)) is in general
++     no longer valid, since traversing along object dependency-links
++     may "find" the main object even when it is not included in the initial
++     order (e.g. a dlopen()'ed shared object can have circular dependencies
++     linked back to itself). In such a case, traversing N-1 objects will
++     create a N-object result, and raise problems.
++
++     To summarize, just passing in the full list, and iterating from back
++     to front makes things much more straightforward.  */
++
++  /* Array to hold RPO sorting results, before we copy back to maps[].  */
++  struct link_map *rpo[nmaps];
++
++  /* The 'head' position during each DFS iteration. Note that we start at
++     one past the last element due to first-decrement-then-store (see the
++     bottom of above dfs_traversal() routine).  */
++  struct link_map **rpo_head = &rpo[nmaps];
++
++  bool do_reldeps = false;
++  bool *do_reldeps_ref = (for_fini ? &do_reldeps : NULL);
++
++  for (int i = nmaps - 1; i >= 0; i--)
++    {
++      dfs_traversal (&rpo_head, maps[i], do_reldeps_ref);
++
++      /* We can break early if all objects are already placed.  */
++      if (rpo_head == rpo)
++	goto end;
++    }
++  assert (rpo_head == rpo);
++
++ end:
++  /* Here we may do a second pass of sorting, using only l_initfini[]
++     static dependency links. This is avoided if !FOR_FINI or if we didn't
++     find any reldeps in the first DFS traversal.
++
++     The reason we do this is: while it is unspecified how circular
++     dependencies should be handled, the presumed reasonable behavior is to
++     have destructors to respect static dependency links as much as possible,
++     overriding reldeps if needed. And the first sorting pass, which takes
++     l_initfini/l_reldeps links equally, may not preserve this priority.
++
++     Hence we do a 2nd sorting pass, taking only DT_NEEDED links into account
++     (see how the do_reldeps argument to dfs_traversal() is NULL below).  */
++  if (do_reldeps)
++    {
++      for (int i = nmaps - 1; i >= 0; i--)
++	rpo[i]->l_visited = 0;
++
++      struct link_map **maps_head = &maps[nmaps];
++      for (int i = nmaps - 1; i >= 0; i--)
++	{
++	  dfs_traversal (&maps_head, rpo[i], NULL);
++
++	  /* We can break early if all objects are already placed.
++	     The below memcpy is not needed in the do_reldeps case here,
++	     since we wrote back to maps[] during DFS traversal.  */
++	  if (maps_head == maps)
++	    return;
++	}
++      assert (maps_head == maps);
++      return;
+     }
++
++  memcpy (maps, rpo, sizeof (struct link_map *) * nmaps);
++}
++
++void
++_dl_sort_maps (struct link_map **maps, unsigned int nmaps,
++	       unsigned int skip, bool for_fini)
++{
++  /* It can be tempting to use a static function pointer to store and call
++     the current selected sorting algorithm routine, but experimentation
++     shows that current processors still do not handle indirect branches
++     that efficiently, plus a static function pointer will involve
++     PTR_MANGLE/DEMANGLE, further impairing performance of small, common
++     input cases. A simple if-case with direct function calls appears to
++     be the fastest.  */
++    _dl_sort_maps_dfs (maps, nmaps, skip, for_fini);
+ }
+diff --git a/elf/rtld.c b/elf/rtld.c
+index e0752eb..e1d056b 100644
+--- a/elf/rtld.c
++++ b/elf/rtld.c
+@@ -1340,6 +1340,9 @@ of this helper program; chances are you did not intend to run this program.\n\
+       main_map->l_name = (char *) "";
+       *user_entry = main_map->l_entry;
+ 
++      /* Set bit indicating this is the main program map.  */
++      main_map->l_main_map = 1;
++
+ #ifdef HAVE_AUX_VECTOR
+       /* Adjust the on-stack auxiliary vector so that it looks like the
+ 	 binary was executed directly.  */
+diff --git a/include/link.h b/include/link.h
+index aea2684..3a87694 100644
+--- a/include/link.h
++++ b/include/link.h
+@@ -177,6 +177,11 @@ struct link_map
+     unsigned int l_init_called:1; /* Nonzero if DT_INIT function called.  */
+     unsigned int l_global:1;	/* Nonzero if object in _dl_global_scope.  */
+     unsigned int l_reserved:2;	/* Reserved for internal use.  */
++    unsigned int l_main_map:1;  /* Nonzero for the map of the main program.  */
++    unsigned int l_visited:1;   /* Used internally for map dependency
++				  graph traversal.  */
++    unsigned int l_map_used:1;  /* These two bits are used during traversal */
++    unsigned int l_map_done:1;  /* of maps in _dl_close_worker. */
+     unsigned int l_phdr_allocated:1; /* Nonzero if the data structure pointed
+ 					to by `l_phdr' is allocated.  */
+     unsigned int l_soname_added:1; /* Nonzero if the SONAME is for sure in
+diff --git a/sysdeps/generic/ldsodefs.h b/sysdeps/generic/ldsodefs.h
+index d7e1515..5bed748 100644
+--- a/sysdeps/generic/ldsodefs.h
++++ b/sysdeps/generic/ldsodefs.h
+@@ -1010,7 +1010,7 @@ extern void _dl_fini (void) attribute_hidden;
+ 
+ /* Sort array MAPS according to dependencies of the contained objects.  */
+ extern void _dl_sort_maps (struct link_map **maps, unsigned int nmaps,
+-			   char *used, bool for_fini) attribute_hidden;
++			   unsigned int skip, bool for_fini) attribute_hidden;
+ 
+ /* The dynamic linker calls this function before and having changing
+    any shared object mappings.  The `r_state' member of `struct r_debug'

--- a/scripts/update-specfile.sh
+++ b/scripts/update-specfile.sh
@@ -5,6 +5,8 @@ specfile=rpmbuild/SPECS/glibc.spec
 
 last_patchnum=$(egrep '^Patch[0-9]+' $specfile | tail -1 | sed 's/^Patch\([0-9]\+\):.*/\1/')
 
+sed -i "/^Patch${last_patchnum}:/a Patch$((last_patchnum+1)): unsubmitted-mathworks-0-bz17645.v2.28-rhel.patch" $specfile
+last_patchnum=$((last_patchnum+1))
 sed -i "/^Patch${last_patchnum}:/a Patch$((last_patchnum+1)): glibc-bz19329-1-of-2.el8.patch" $specfile
 last_patchnum=$((last_patchnum+1))
 sed -i "/^Patch${last_patchnum}:/a Patch$((last_patchnum+1)): glibc-bz19329-2-of-2.el8.patch" $specfile


### PR DESCRIPTION
The update-specifle.sh script for rhel won't work because bz19329 no longer need to be patched. You need to comment out line 9 to line 14 in update-specifile.sh in order to test the bz-17645 patch